### PR TITLE
Added recognizeWithBounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ react-native-tesseract-ocr is a react-native wrapper for [Tesseract OCR](https:/
 
 ## Getting started
 
-`$ npm install react-native-tesseract-ocr --save` 
+`$ npm install react-native-tesseract-ocr --save`
 
 or
 
-`$ yarn add react-native-tesseract-ocr` 
+`$ yarn add react-native-tesseract-ocr`
 
 ### Mostly automatic installation
 
@@ -48,13 +48,18 @@ or
   	```
       compile project(':react-native-tesseract-ocr')
   	```
-4. [v3.04 Trained data files](https://github.com/tesseract-ocr/tessdata/tree/3.04.00) for a language must be 
+4. [v3.04 Trained data files](https://github.com/tesseract-ocr/tessdata/tree/3.04.00) for a language must be
 extracted in `android/app/src/main/assets/tessdata`.
 
 ## Usage
+
+Two methods are provided:
+
+* `recognize` - For single-block text recognition (returns the complete text string)
+* `recognizeWithBounds` - For individual word recognition (returns each word and its bounding box)
+
 ```javascript
 import RNTesseractOcr from 'react-native-tesseract-ocr';
-
 
 /**
  * @param {string} imgPath - The path of the image.
@@ -62,9 +67,11 @@ import RNTesseractOcr from 'react-native-tesseract-ocr';
  * @param {object} tessOptions - Tesseract options.
  */
  const tessOptions = {
-  whitelist: null, 
+  whitelist: null,
   blacklist: '1234567890\'!"#$%&/()={}[]+*-_:;<>'
 };
+
+// performs a recognition and returns all the text in a single string
 RNTesseractOcr.recognize(imgPath, lang, tessOptions)
   .then((result) => {
     this.setState({ ocrResult: result });
@@ -75,9 +82,22 @@ RNTesseractOcr.recognize(imgPath, lang, tessOptions)
   })
   .done();
 
+// performs a recognition and returns an array with all individual words and their respective bounding boxes
+RNTesseractOcr.recognizeWithBounds(imgPath, lang, tessOptions)
+  .then((result) => {
+    this.setState({ ocrResult: result });
+
+    result.forEach((word, i) => {
+        console.log(`OCR Result ${i}: `, word["text"], word["x1"], word["y1"], word["x2"], word["y2"]);
+    });
+  })
+  .catch((err) => {
+    console.log("OCR Error: ", err);
+  })
+  .done();
 ```
 
-*NOTE: The method _startOcr_ is deprecated. Instead, use _recognize_*
+*NOTE: The method _startOcr_ is deprecated. Instead, use _recognize_ or _recognizeWithBounds_*
 
 
 ### Supported languages
@@ -124,11 +144,11 @@ RNTesseractOcr.recognize(imgPath, lang, tessOptions)
 
 ### If you want to use your own trained data file
   - LANG_CUSTOM
- 
+
  *Locate your own trained data file as `custom.traineddata` into `android/app/src/main/assets/tessdata`.*
 
 
-## Example 
+## Example
 Try the included [TesseractOcrSample](https://github.com/jonathanpalma/react-native-tesseract-ocr/tree/master/tesseractOcrSample):
 - `git clone git@github.com:jonathanpalma/react-native-tesseract-ocr.git`
 - `cd react-native-tesseract-ocr/tesseractOcrSample/`
@@ -148,8 +168,8 @@ Check the [project boards](https://github.com/jonathanpalma/react-native-tessera
 Contributions are welcome :raised_hands:
 
 ## License
-This repository is distributed under [MIT license](https://github.com/jonathanpalma/react-native-tesseract-ocr/blob/master/LICENSE) 
+This repository is distributed under [MIT license](https://github.com/jonathanpalma/react-native-tesseract-ocr/blob/master/LICENSE)
  - [Tesseract OCR](https://github.com/tesseract-ocr) - maintained by Google, is distributed under [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0)
  - [tess-two](https://github.com/rmtheis/tess-two) is distributed under [Apache 2.0 license](https://github.com/rmtheis/tess-two/blob/master/COPYING)
  - [Tesseract-OCR-iOS](https://github.com/gali8/Tesseract-OCR-iOS) is distributed under [MIT license](https://github.com/gali8/Tesseract-OCR-iOS/blob/master/LICENSE.md)
- 
+

--- a/android/src/main/java/com/reactlibrary/RNTesseractOcrModule.java
+++ b/android/src/main/java/com/reactlibrary/RNTesseractOcrModule.java
@@ -253,6 +253,7 @@ public class RNTesseractOcrModule extends ReactContextBaseJavaModule {
 		} while (it.next(level));
 
 		it.delete();
+		tessBaseApi.end();
 
 		return words;
 	}

--- a/android/src/main/java/com/reactlibrary/RNTesseractOcrModule.java
+++ b/android/src/main/java/com/reactlibrary/RNTesseractOcrModule.java
@@ -3,6 +3,7 @@ package com.reactlibrary;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Rect;
 import android.os.Environment;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -13,8 +14,13 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 
+import com.googlecode.tesseract.android.ResultIterator;
 import com.googlecode.tesseract.android.TessBaseAPI;
 
 import java.io.File;
@@ -174,7 +180,31 @@ public class RNTesseractOcrModule extends ReactContextBaseJavaModule {
 			String result = extractText(bitmap, lang, tessOptions);
 
 			promise.resolve(result);
+		} catch (Exception e) {
+			Log.e(REACT_CLASS, e.getMessage());
+			promise.reject("An error occurred", e.getMessage());
+		}
+	}
 
+	@ReactMethod
+	public void recognizeWithBounds(String path, String lang, @Nullable ReadableMap tessOptions, Promise promise) {
+		prepareTesseract();
+
+		Log.d(REACT_CLASS, "Start ocr images with bounds");
+
+		try {
+			BitmapFactory.Options options = new BitmapFactory.Options();
+
+			// TODO:
+			// Check image size before use inSampleSize (maybe this could help) --> https://goo.gl/4MvBvB
+			// considering that when inSampleSize is used (usually to save memory) the ocr quality decreases
+
+			//options.inSampleSize = 4; //inSampleSize documentation --> http://goo.gl/KRrlvi
+			Bitmap bitmap = BitmapFactory.decodeFile(path, options);
+
+			WritableArray result = extractTextWithBounds(bitmap, lang, TessBaseAPI.PageIteratorLevel.RIL_WORD, tessOptions);
+
+			promise.resolve(result);
 		} catch (Exception e) {
 			Log.e(REACT_CLASS, e.getMessage());
 			promise.reject("An error occurred", e.getMessage());
@@ -182,6 +212,52 @@ public class RNTesseractOcrModule extends ReactContextBaseJavaModule {
 	}
 
 	private String extractText(Bitmap bitmap, String lang, @Nullable final ReadableMap tessOptions) {
+		createTesseractApi(lang, tessOptions);
+
+		tessBaseApi.setImage(bitmap);
+
+		String extractedText = "Empty result";
+		try {
+			extractedText = tessBaseApi.getUTF8Text();
+		} catch (Exception e) {
+			Log.e(REACT_CLASS, "Error in recognizing text: " + e.getMessage());
+		}
+
+		tessBaseApi.end();
+
+		return extractedText;
+	}
+
+	private WritableArray extractTextWithBounds(Bitmap bitmap, String lang, int level, @Nullable final ReadableMap tessOptions) {
+		createTesseractApi(lang, tessOptions);
+
+		tessBaseApi.setImage(bitmap);
+		tessBaseApi.getUTF8Text();
+
+		WritableArray words = new WritableNativeArray();
+		ResultIterator it = tessBaseApi.getResultIterator();
+		it.begin();
+
+		do {
+			String word = it.getUTF8Text(level);
+			Rect region = it.getBoundingRect(level);
+			WritableMap map = new WritableNativeMap();
+
+			map.putString("text", word);
+			map.putInt("x1", region.left);
+			map.putInt("y1", region.top);
+			map.putInt("x2", region.right);
+			map.putInt("y2", region.bottom);
+
+			words.pushMap(map);
+		} while (it.next(level));
+
+		it.delete();
+
+		return words;
+	}
+
+	private void createTesseractApi(String lang, @Nullable final ReadableMap tessOptions) {
 		try {
 			tessBaseApi = new TessBaseAPI();
 		} catch (Exception e) {
@@ -211,19 +287,6 @@ public class RNTesseractOcrModule extends ReactContextBaseJavaModule {
 		}
 
 		Log.d(REACT_CLASS, "Training file loaded");
-
-		tessBaseApi.setImage(bitmap);
-
-		String extractedText = "Empty result";
-		try {
-			extractedText = tessBaseApi.getUTF8Text();
-		} catch (Exception e) {
-			Log.e(REACT_CLASS, "Error in recognizing text: " + e.getMessage());
-		}
-
-		tessBaseApi.end();
-
-		return extractedText;
 	}
 
 	private void prepareDirectory(String path) {


### PR DESCRIPTION
Hi!

Thanks for the package. I needed to get the individual words together with their respective bounding boxes, so I added a new method that returns a WritableArray of objects with "text", "x1", "y1", "x2", "y2" properties for each word recognized: `recognizeWithBounds`.

I extracted the shared code into `createTesseractApi`. The original `recognize` method works exactly as before.

Use like `RNTesseractOcr.recognizeWithBounds(...)` with exactly the same arguments. Return type is an array with the above objects.