### PR TITLE
Removed deprecated react native method createJSModules (since v47)

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNTesseractOcrPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNTesseractOcrPackage.java
@@ -17,11 +17,6 @@ public class RNTesseractOcrPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Using latest React Native (v47+) breaks compilation since `createJSModules` is removed. See https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8