### PR TITLE
Upgrade to Tesseract 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ MIT © [jonathanpalma](https://github.com/jonathanpalma)
 This library wouldn't be possible without these amazing projects:
 
 - [Tesseract OCR][url-tesseract] - [Apache 2.0 license][url-tesseract-lsc]
-- [tess-two][url-tess-and] - [Apache 2.0 license][url-tess-and-lsc]
+- [Tesseract4Android][url-tess-and] - [Apache 2.0 license][url-tess-and-lsc]
 <!-- - [Tesseract-OCR-iOS][url-tess-ios] - [MIT license][url-tess-ios-lsc] -->
 
 [downloads-badge]: https://img.shields.io/npm/dm/react-native-tesseract-ocr.svg?style=flat-square
@@ -149,8 +149,8 @@ This library wouldn't be possible without these amazing projects:
 [url-prettier]: https://prettier.io/
 [url-tesseract]: https://github.com/tesseract-ocr/tesseract
 [url-tesseract-lsc]: https://github.com/tesseract-ocr/tesseract/blob/master/LICENSE
-[url-tess-and]: https://github.com/rmtheis/tess-two
-[url-tess-and-lsc]: https://github.com/rmtheis/tess-two/blob/master/COPYING
+[url-tess-and]: https://github.com/adaptech-cz/Tesseract4Android
+[url-tess-and-lsc]: https://github.com/adaptech-cz/Tesseract4Android#license
 [url-tess-ios]: https://github.com/gali8/Tesseract-OCR-iOS
 [url-tess-ios-lsc]: https://github.com/gali8/Tesseract-OCR-iOS/blob/master/LICENSE.md
 [twitter]: https://twitter.com/intent/tweet?text=Check%20out%20react-native-tesseract-ocr!%20https://github.com/jonathanpalma/react-native-tesseract-ocr

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.rmtheis:tess-two:9.1.0'
+    implementation 'cz.adaptech.android:tesseract4android:2.1.1'
 }
 
 def configureReactNativePom(def pom) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare module "react-native-tesseract-ocr" {
     | typeof LANG_LATIN
     | typeof LANG_LITHUANIAN
     | typeof LANG_NEPALI
+    | typeof LANG_NEDERLAND
     | typeof LANG_NORWEGIAN
     | typeof LANG_PERSIAN
     | typeof LANG_POLISH

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare module "react-native-tesseract-ocr" {
   export const LANG_LATIN = "lat";
   export const LANG_LITHUANIAN = "lit";
   export const LANG_NEPALI = "nep";
+  export const LANG_NEDERLAND = "nld"
   export const LANG_NORWEGIAN = "nor";
   export const LANG_PERSIAN = "fas";
   export const LANG_POLISH = "pol";

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ export const LANG_KOREAN = "kor";
 export const LANG_LATIN = "lat";
 export const LANG_LITHUANIAN = "lit";
 export const LANG_NEPALI = "nep";
+export const LANG_NEDERLAND = "nld"
 export const LANG_NORWEGIAN = "nor";
 export const LANG_PERSIAN = "fas";
 export const LANG_POLISH = "pol";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4702,10 +4702,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-"projects@link:..":
-  version "0.0.0"
-  uid ""
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
I thought this would be more complicated but I have tested it in my own apps and I do not get any errors using recognisedTokens with Line level. 

4.1 seems to run slower than 3.0 on Android with my use case however it I am getting better OCR with it. So its a double edged sword.